### PR TITLE
Hold multiple post requests while moving or rotating stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+* Updated documentation on README.md for complete callback
+
 ## 0.3.1
 * Hold off multiple post requests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.1
+* Hold off multiple post requests
+
 ## 0.3.0
 * Allow dynamic minimum point detection limit
 * Upgraded stamp recognition animation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Snowshoe jQuery
 Front-end client to submit Snowshoe stamp point data to your backend.
 
 ## Current Version
-- 0.3.0
+- 0.3.1
 
 ## Dependencies
 - jQuery (>= 1.8.x)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Snowshoe jQuery
 Front-end client to submit Snowshoe stamp point data to your backend.
 
 ## Current Version
-- 0.3.1
+- 0.3.2
 
 ## Dependencies
 - jQuery (>= 1.8.x)
@@ -24,7 +24,10 @@ At the bottom of any page you want to make "stampable", create an object with in
 <script src="jquery.snowshoe.js"></script>
 ```
 
-Optionally, post via AJAX and handle success/failure in the client.
+Optionally, post via AJAX and handle success/failure/complete in the client.
+
+**_NOTE:_** Whenever stamp data is submitted by Ajax, it waits for request completion before generating another Ajax request.
+
 ```javascript
 <script>
 var stampScreenInitData = {
@@ -38,6 +41,10 @@ var stampScreenInitData = {
   "error": function(response){
     // handle failure
     console.log(" :-( ");
+  },
+  "complete": function(response){
+    // Do something on complete
+    console.log(" All Done ");
   }
 }
 </script>
@@ -74,13 +81,15 @@ var stampScreenInitData = {
   "success": function(response){
     // handle success
     console.log("Success!");
-    // clear animation
-    $('#snowshoe-progress-bar').removeClass("snowshoe-progress-bar");
   },
   "error": function(response){
     // handle failure
     console.log(" :-( ");
-    // clear animation
+  },
+  "complete": function(response){
+    // handle complete
+    console.log(" All Done ");
+	// clear animation
     $('#snowshoe-progress-bar').removeClass("snowshoe-progress-bar");
   }
 }

--- a/jquery.snowshoe.js
+++ b/jquery.snowshoe.js
@@ -1,7 +1,7 @@
 /*
 Snowshoe jQuery (https://github.com/snowshoestamp/snowshoe_jquery)
 jquery.snowshoe.js
-Version 0.3.1
+Version 0.3.2
 See GitHub project page for Documentation and License
 */
 

--- a/jquery.snowshoe.js
+++ b/jquery.snowshoe.js
@@ -1,7 +1,7 @@
 /*
 Snowshoe jQuery (https://github.com/snowshoestamp/snowshoe_jquery)
 jquery.snowshoe.js
-Version 0.3.0
+Version 0.3.1
 See GitHub project page for Documentation and License
 */
 


### PR DESCRIPTION
Multiple requests were being generated while moving stamp over screen.
Updated to version 0.3.1
